### PR TITLE
changing interface auth mechanisms 

### DIFF
--- a/gbdxtools/auth.py
+++ b/gbdxtools/auth.py
@@ -1,0 +1,26 @@
+from gbdx_auth import gbdx_auth
+from traitlets.config.configurable import SingletonConfigurable
+import logging
+
+class Interface(SingletonConfigurable):
+    gbdx_connection = gbdx_auth.get_session()
+
+    logger = logging.getLogger('gbdxtools')
+    logger.setLevel(logging.ERROR)
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.ERROR)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+    logger.info('Logger initialized')
+
+    def __call__(self, **kwargs):
+        if (kwargs.get('username') and kwargs.get('password') and
+                kwargs.get('client_id') and kwargs.get('client_secret')):
+            self.gbdx_connection = gbdx_auth.session_from_kwargs(**kwargs)
+        elif kwargs.get('gbdx_connection'):
+            # Pass in a custom gbdx connection object, for testing purposes
+            self.gbdx_connection = kwargs.get('gbdx_connection')
+        else:
+            # This will throw an exception if your .ini file is not set properly
+            self.gbdx_connection = gbdx_auth.get_session(kwargs.get('config_file'))

--- a/gbdxtools/interface.py
+++ b/gbdxtools/interface.py
@@ -11,17 +11,15 @@ import json
 import os
 import logging
 
-from gbdx_auth import gbdx_auth
-
+from gbdxtools.auth import Interface as Auth
 from gbdxtools.s3 import S3
 from gbdxtools.ordering import Ordering
 from gbdxtools.workflow import Workflow
 from gbdxtools.catalog import Catalog
 from gbdxtools.vectors import Vectors
 from gbdxtools.idaho import Idaho
-from gbdxtools.image import Image
 from gbdxtools.ipe_image import IpeImage
-from gbdxtools.ipe.interface import Ipe
+from gbdxtools.image import Image
 from gbdxtools.task_registry import TaskRegistry
 import gbdxtools.simpleworkflows
 
@@ -30,15 +28,7 @@ class Interface(object):
     gbdx_connection = None
 
     def __init__(self, **kwargs):
-        if (kwargs.get('username') and kwargs.get('password') and
-                kwargs.get('client_id') and kwargs.get('client_secret')):
-            self.gbdx_connection = gbdx_auth.session_from_kwargs(**kwargs)
-        elif kwargs.get('gbdx_connection'):
-            # Pass in a custom gbdx connection object, for testing purposes
-            self.gbdx_connection = kwargs.get('gbdx_connection')
-        else:
-            # This will throw an exception if your .ini file is not set properly
-            self.gbdx_connection = gbdx_auth.get_session(kwargs.get('config_file'))
+        self.gbdx_connection = Auth.instance(**kwargs).gbdx_connection
 
         # create a logger
         # for now, just log to the console. We'll replace all the 'print' statements 
@@ -70,11 +60,8 @@ class Interface(object):
 
         self.vectors = Vectors(self)
 
-        self.ipe = Ipe()
-
-        self.image = Image(self)
-
-        self.ipeimage = IpeImage(self)
+        self.image = Image
+        self.ipeimage = IpeImage
 
         self.task_registry = TaskRegistry(self)
 

--- a/gbdxtools/ipe/interface.py
+++ b/gbdxtools/ipe/interface.py
@@ -2,9 +2,9 @@ import uuid
 import json
 import types
 import copy
-import gbdxtools.ipe_image
 from hashlib import sha256
 from itertools import chain
+import gbdxtools as gbdx
 
 NAMESPACE_UUID = uuid.NAMESPACE_DNS
 
@@ -33,7 +33,7 @@ class Op(object):
         return str(uuid.uuid5(NAMESPACE_UUID, json.dumps(self._nodes)))
 
     def __call__(self, *args, **kwargs):
-        if len(args) > 0 and all([isinstance(arg, gbdxtools.ipe_image.IpeImage) for arg in args]):
+        if len(args) > 0 and all([isinstance(arg, gbdx.ipe_image.IpeImage) for arg in args]):
             return self._ipe_image_call(*args, **kwargs)
         self._nodes = [ContentHashedDict({"operator": self._operator,
                                           "_ancestors": [arg._id for arg in args], 
@@ -55,7 +55,7 @@ class Op(object):
             del kwargs['_intermediate']
         out = self(*[arg.ipe for arg in args], **kwargs)
         key = self._id
-        ipe_img = args[0].interface.ipeimage(args[0]._idaho_id, key, _ipe_graphs={key: out})
+        ipe_img = gbdx.ipe_image.IpeImage(args[0]._idaho_id, key, _ipe_graphs={key: out})
         return ipe_img
 
     def graph(self):

--- a/gbdxtools/ipe_image.py
+++ b/gbdxtools/ipe_image.py
@@ -44,6 +44,7 @@ from gbdxtools.ipe.util import calc_toa_gain_offset
 from gbdxtools.ipe.graph import register_ipe_graph
 from gbdxtools.ipe.error import NotFound
 from gbdxtools.ipe.interface import Ipe
+from gbdxtools.auth import Interface
 ipe = Ipe()
 
 @delayed
@@ -72,30 +73,26 @@ class IpeImage(da.Array):
     """
       Dask based access to ipe based images (Idaho).
     """
-    def __init__(self, interface):
-        self.interface = interface
-
-    def __call__(self, idaho_id, node="toa_reflectance", **kwargs):
-        obj = IpeImage(self.interface)
-        obj._idaho_id = idaho_id
-        obj._node_id = node
-        obj._level = 0
-        obj._idaho_md = None
-        obj._ipe_id = None
+    def __init__(self, idaho_id, node="toa_reflectance", **kwargs):
+        self.interface = Interface.instance()
+        self._idaho_id = idaho_id
+        self._node_id = node
+        self._level = 0
+        self._idaho_md = None
+        self._ipe_id = None
         if '_ipe_graphs' in kwargs:
-            obj._ipe_graphs = kwargs['_ipe_graphs']
+            self._ipe_graphs = kwargs['_ipe_graphs']
         else:
-            obj._ipe_graphs = obj._init_graphs()
+            self._ipe_graphs = self._init_graphs()
         if kwargs.get('_intermediate', False):
-            return obj
-        obj._bounds = obj._parse_geoms(**kwargs)
-        obj._graph_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, str(obj.ipe.graph())))
-        obj._tile_size = kwargs.get('tile_size', 256)
-        with open(obj.vrt) as f:
-            obj._vrt = f.read()
-        obj._cfg = obj._config_dask(bounds=obj._bounds)
-        super(IpeImage, obj).__init__(**obj._cfg)
-        return obj
+            return self 
+        self._bounds = self._parse_geoms(**kwargs)
+        self._graph_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, str(self.ipe.graph())))
+        self._tile_size = kwargs.get('tile_size', 256)
+        with open(self.vrt) as f:
+            self._vrt = f.read()
+        self._cfg = self._config_dask(bounds=self._bounds)
+        super(IpeImage, self).__init__(**self._cfg)
 
     @property
     def idaho_md(self):
@@ -137,7 +134,7 @@ class IpeImage(da.Array):
 
     def aoi(self, **kwargs):
         """ Subsets the IpeImage by the given bounds """
-        return self.interface.ipeimage(self._idaho_id, **kwargs)
+        return IpeImage(self._idaho_id, **kwargs)
 
     def metadata(self):
         with self.open() as src:
@@ -251,7 +248,6 @@ class IpeImage(da.Array):
         toa_reflectance = ipe.MultiplyConst(radiance, constants=reflectance_scales)
 
         return {"ortho": ortho, "radiance": radiance, "toa_reflectance": toa_reflectance}
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Uses a traitlets singleton configurable interface to create sessions from gbdx_auth. Avoids the need to support a __call__ method to image classes. The auth interface is also shared between the regular gbdx interface and the image classes. 